### PR TITLE
Mergify integration

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,13 @@
+pull_request_rules:
+  - name: automatic merge for PyUp pull requests
+    conditions:
+      - author=pyup-bot
+      - status-success=Travis CI - Pull Request
+    actions:
+      merge:
+        method: merge
+  - name: delete head branch after merge
+    conditions:
+      - merged
+    actions:
+      delete_head_branch: {}


### PR DESCRIPTION
Although Pyup-bot automates keeping track of dependencies, it may be boring to manually merge each bot's pull request and then delete that merged branch. Here is when [Mergify](https://mergify.io/) comes into play: it automatically merges pull requests under requested conditions and is absolutely free for public repositories. In my added YAML file, I added support for automating merging Pyup's pull requests (after Travis CI checks, sure!) and then deleting a redundant merged branch.

You, as the author of this package, will only need to register on their official website (the link is above) and grant access to the nider repository (Mergify is free for public repositories).

After this, you can forget about dependencies as well as merging them.

Official Mergify's documentation for more information: [https://doc.mergify.io/](https://doc.mergify.io/)