### PR TITLE
Resolving Travis CI fails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,13 @@ deploy:
     python: 3.6
     repo: pythad/nider
     tags: true
+before_install:
+    - python --version
+    - pip install -U pip
 install: pip install -U tox-travis
 language: python
 python:
-- 3.6
-- 3.5
-- 3.4
+    - 3.6
+    - 3.5
+    - 3.4
 script: tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ before_install:
     - python --version
     - python -m pip install --upgrade pip
     - pip --version
+    - pip install -r requirements/dev.txt
 install: pip install -U tox-travis
 language: python
 python:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,16 +5,17 @@ deploy:
   user: pythad
   distributions: sdist bdist_wheel
   on:
-    python: 3.6
+    python: 3.8
     repo: pythad/nider
     tags: true
 before_install:
     - python --version
     - pip install -U pip
+    - pip --version
 install: pip install -U tox-travis
 language: python
 python:
+    - 3.8
+    - 3.7
     - 3.6
-    - 3.5
-    - 3.4
 script: tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ deploy:
     tags: true
 before_install:
     - python --version
-    - pip install --upgrade pip
+    - python -m pip install --upgrade pip
     - pip --version
 install: pip install -U tox-travis
 language: python

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,4 @@ python:
     - 3.8
     - 3.7
     - 3.6
-script: python setup.py test
+script: tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ deploy:
     tags: true
 before_install:
     - python --version
-    - pip install --upgrade --user pip
+    - pip install --upgrade pip
     - pip --version
 install: pip install -U tox-travis
 language: python

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ deploy:
     tags: true
 before_install:
     - python --version
-    - pip install -U pip
+    - pip install --upgrade --user pip
     - pip --version
 install: pip install -U tox-travis
 language: python

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,4 @@ python:
     - 3.8
     - 3.7
     - 3.6
-script: tox
+script: python setup.py test

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,12 +1,10 @@
 -r prod.txt
 
-pip==19.0.3
-bumpversion==0.5.3
-wheel==0.33.1
-watchdog==0.9.0
-flake8==3.7.7
-tox==3.8.4
-coverage==4.5.3
-Sphinx==2.0.0
-cryptography==2.6.1
-PyYAML==5.1
+bumpversion==0.6.0
+watchdog==0.10.3
+flake8==3.8.3
+tox==3.19.0
+coverage==5.2.1
+Sphinx==3.2.0
+cryptography==3.0
+PyYAML==5.3.1

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,2 +1,2 @@
 colorthief==0.2.1
-Pillow==6.0.0
+Pillow==7.2.0

--- a/setup.py
+++ b/setup.py
@@ -32,9 +32,12 @@ parsed_test_requirements = parse_requirements(
     'requirements/test.txt',
     session=PipSession()
 )
-
-requirements = [str(ir.requirement) for ir in parsed_requirements]
-test_requirements = [str(tr.requirement) for tr in parsed_test_requirements]
+try:
+    requirements = [str(ir.req) for ir in parsed_requirements]
+    test_requirements = [str(tr.req) for tr in parsed_test_requirements]
+except AttributeError:
+    requirements = [str(ir.requirement) for ir in parsed_requirements]
+    test_requirements = [str(tr.requirement) for tr in parsed_test_requirements]
 
 setup(
     name='nider',

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ except ImportError:  # for pip <= 9.0.3
 from setuptools import setup, find_packages
 
 try:  # for pip >= 10
-    from pip._internal.download import PipSession
+    from pip._internal.network.session import PipSession
 except ImportError:  # for pip <= 9.0.3
     from pip.download import PipSession
 
@@ -33,8 +33,8 @@ parsed_test_requirements = parse_requirements(
     session=PipSession()
 )
 
-requirements = [str(ir.req) for ir in parsed_requirements]
-test_requirements = [str(tr.req) for tr in parsed_test_requirements]
+requirements = [str(ir.requirement) for ir in parsed_requirements]
+test_requirements = [str(tr.requirement) for tr in parsed_test_requirements]
 
 setup(
     name='nider',

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ from setuptools import setup, find_packages
 try:  # for pip >= 10
     from pip._internal.network.session import PipSession
 except ImportError:  # for pip <= 9.0.3
-    from pip.download import PipSession
+    from pip._internal.download import PipSession
 
 
 with open('README.rst') as readme_file:

--- a/tox.ini
+++ b/tox.ini
@@ -1,23 +1,25 @@
 [tox]
-envlist = py34, py35, flake8
+envlist = py36, py37, py38, flake8
 
 [travis]
 python =
+    3.8: py38
+    3.7: py37
     3.6: py36
-    3.5: py35
-    3.4: py34
 
 [testenv:flake8]
 basepython=python
 deps=flake8
-commands=flake8 nider
-ignore = E501,E101
+commands=flake8 nider/
+
+[flake8]
+ignore=E501,F401,F841,W504
 
 [testenv]
 setenv =
     PYTHONPATH = {toxinidir}
-
-commands = python setup.py test
+deps =
+commands = python -m unittest discover
 
 ; If you want to make tox run the tests with the same versions, create a
 ; requirements.txt with the pinned versions and uncomment the following lines:

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ ignore=E501,F401,F841,W504
 setenv =
     PYTHONPATH = {toxinidir}
 deps =
-commands = python -m unittest discover
+commands = python setup.py test
 
 ; If you want to make tox run the tests with the same versions, create a
 ; requirements.txt with the pinned versions and uncomment the following lines:


### PR DESCRIPTION
The package had several issues which led to Travis CI fails. Here are the changes I made:
1. Refreshed Python version (changed from Python3.4-3.6 to Python3.6-3.8).
2. Updated pip in `before_install` in Travis YAML (by default, it used pip v.19). Moreover, this package now works **both** for CI and an end user (tested by me on Ubuntu 20.04 and using Python3.8, `pip`==20.2.2).
3. Updated `requirements` (although they were not insecure, most of them were outdated).
4. Removed potentially dangerous requirements: `pip` and `wheel`. Click [here](https://github.com/jazzband/pip-tools/issues/522) for more info.
5. Modified `setup.py`: using `try`/`except` blocks can handle both 20 > `pip` >= 10 _and_ `pip` >= 20.
6. In `tox.ini` all Python versions are specified (in previous `py36` was not clarified which led to deprecation warning by Travis CI).
7. In `tox.ini` flake8-ignore did not work: now it is resolved and any occuring warnings are specified.

Sorry for inconvenience, I know pull requests are supposed to be small, but I feel I have played around it for a long time.