### PR TITLE
This closes #231

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,9 +56,9 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6'
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8'
     ],
     test_suite='tests',
     tests_require=test_requirements,


### PR DESCRIPTION
Confronted classifiers in `setup.py` to the Python versions in `tox.ini` and `.travis.yml`.